### PR TITLE
Feat: useModal - 모달 공용 커스텀 훅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
             "name": "slideto-do",
             "version": "0.1.0",
             "dependencies": {
+                "motion": "^12.23.0",
                 "next": "15.3.4",
                 "react": "^19.0.0",
-                "react-dom": "^19.0.0"
+                "react-dom": "^19.0.0",
+                "zustand": "^5.0.6"
             },
             "devDependencies": {
                 "@eslint/eslintrc": "^3",
@@ -1620,7 +1622,7 @@
             "version": "19.1.8",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
             "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.0.2"
@@ -2955,7 +2957,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/damerau-levenshtein": {
@@ -4371,6 +4373,33 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/framer-motion": {
+            "version": "12.23.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.0.tgz",
+            "integrity": "sha512-xf6NxTGAyf7zR4r2KlnhFmsRfKIbjqeBupEDBAaEtVIBJX96sAon00kMlsKButSIRwPSHjbRrAPnYdJJ9kyhbA==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^12.22.0",
+                "motion-utils": "^12.19.0",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/function-bind": {
@@ -5848,6 +5877,47 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/motion": {
+            "version": "12.23.0",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.0.tgz",
+            "integrity": "sha512-PPNwblArRH9GRC4F3KtOTiIaYd+mtp324vYq3HIL+ueseoAVqPRK5TPFTAQBcIprfVd0NWo3DLzZSiyWaYFXXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "framer-motion": "^12.23.0",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/motion-dom": {
+            "version": "12.22.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
+            "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^12.19.0"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "12.19.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+            "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -8139,6 +8209,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+            "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0",
+                "immer": ">=9.0.6",
+                "react": ">=18.0.0",
+                "use-sync-external-store": ">=1.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "use-sync-external-store": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
         "tsc": "tsc"
     },
     "dependencies": {
+        "motion": "^12.23.0",
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.6"
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import {Geist, Geist_Mono} from 'next/font/google'
 
+import ModalProvider from './providers/modal-provider'
+
 import type {Metadata} from 'next'
+
 import './globals.css'
 
 const geistSans = Geist({
@@ -25,7 +28,10 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="en">
-            <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+            <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+                {children}
+                <ModalProvider />
+            </body>
         </html>
     )
 }

--- a/src/app/providers/modal-provider.tsx
+++ b/src/app/providers/modal-provider.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import {AnimatePresence} from 'motion/react'
+
+import {useModalStore} from '../store/use-modal-store'
+
+export default function ModalProvider() {
+    const {currentModal: modal} = useModalStore()
+
+    return (
+        <div className={`fixed inset-0 ${modal ? 'pointer-events-auto' : 'pointer-events-none'}`}>
+            <AnimatePresence>{modal}</AnimatePresence>
+        </div>
+    )
+}

--- a/src/app/store/use-modal-store.tsx
+++ b/src/app/store/use-modal-store.tsx
@@ -1,0 +1,15 @@
+import {create} from 'zustand'
+
+import type {JSX} from 'react'
+
+interface ModalState {
+    currentModal: JSX.Element | undefined
+    setModal: (modal: JSX.Element) => void
+    clearModal: () => void
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+    currentModal: undefined,
+    setModal: (modal: JSX.Element) => set(() => ({currentModal: modal})),
+    clearModal: () => set({currentModal: undefined}),
+}))

--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import {useEffect, useRef, type JSX} from 'react'
+
+import {motion, type MotionProps} from 'motion/react'
+
+import {useModalStore} from '@/app/store/use-modal-store'
+
+/**
+ * 모달 애니메이션 타입 정의
+ */
+type ModalAnimationType =
+    | 'fadeAndScale'
+    | 'slideFromRight'
+    | 'slideFromLeft'
+    | 'slideFromTop'
+    | 'slideFromBottom'
+    | 'none'
+
+/**
+ * 배경 애니메이션 타입 정의
+ */
+type BackdropAnimationType = 'fade' | 'none'
+
+/**
+ * 모달 옵션 설정
+ */
+interface UseModalOptions {
+    /** ESC 키로 모달 닫기 활성화 여부 (기본값: true) */
+    closeOnEscape?: boolean
+    /** 모달 외부 클릭으로 닫기 활성화 여부 (기본값: true) */
+    closeOnClickOutside?: boolean
+    /** 배경 어둠 처리 활성화 여부 (기본값: true) */
+    backdrop?: boolean
+    /** 배경 애니메이션 타입 (기본값: 'fade') */
+    backdropAnimation?: BackdropAnimationType
+    /** 모달 애니메이션 타입 (기본값: 'fadeAndScale') */
+    modalAnimation?: ModalAnimationType
+}
+
+/**
+ * useModal 훅의 반환 값
+ */
+interface UseModalReturn<T> {
+    /** 모달을 여는 함수 */
+    openModal: (properties?: T) => void
+    /** 모달을 닫는 함수 */
+    closeModal: () => void
+}
+
+/**
+ * 애니메이션 속성 객체 타입
+ */
+type AnimationProperties = Pick<MotionProps, 'initial' | 'animate' | 'exit' | 'transition'>
+
+/**
+ * 모달 관리를 위한 커스텀 훅
+ *
+ * @template T - 모달에 전달할 props의 타입
+ * @param modal - 렌더링할 JSX 요소 또는 props를 받는 함수
+ * @param options - 모달 동작 옵션 설정
+ * @returns 모달 열기/닫기 함수들
+ *
+ * @example
+ * ```tsx
+ * // 정적 모달
+ * const {openModal, closeModal} = useModal(<MyModal />)
+ *
+ * // 동적 모달 (props 전달)
+ * const {openModal} = useModal<{count: number}>((props) => <MyModal count={props.count} />)
+ * openModal({count: 5})
+ *
+ * // 옵션 설정
+ * const {openModal} = useModal(<MyModal />, {
+ *   modalAnimation: 'slideFromRight',
+ *   closeOnEscape: false
+ * })
+ * ```
+ */
+export function useModal<T = unknown>(
+    modal: JSX.Element | ((properties: T) => JSX.Element),
+    options?: UseModalOptions,
+): UseModalReturn<T> {
+    const {currentModal, setModal, clearModal} = useModalStore()
+
+    // 기본값 설정
+    const {
+        closeOnEscape = true,
+        closeOnClickOutside = true,
+        backdrop = true,
+        backdropAnimation = 'fade',
+        modalAnimation = 'fadeAndScale',
+    } = options ?? {}
+
+    const modalReference = useRef<HTMLDivElement>(null)
+
+    /**
+     * 모달 애니메이션 속성을 반환하는 함수
+     */
+    const getModalAnimationProperties = (): AnimationProperties => {
+        switch (modalAnimation) {
+            case 'fadeAndScale': {
+                return {
+                    initial: {opacity: 0, scale: 0.8},
+                    animate: {opacity: 1, scale: 1},
+                    exit: {opacity: 0, scale: 0.8},
+                }
+            }
+
+            case 'slideFromRight': {
+                return {
+                    initial: {x: '100%'},
+                    animate: {x: '0%'},
+                    exit: {x: '100%'},
+                }
+            }
+
+            case 'slideFromLeft': {
+                return {
+                    initial: {x: '-100%'},
+                    animate: {x: '0%'},
+                    exit: {x: '-100%'},
+                }
+            }
+
+            case 'slideFromTop': {
+                return {
+                    initial: {y: '-100%'},
+                    animate: {y: '0%'},
+                    exit: {y: '-100%'},
+                }
+            }
+
+            case 'slideFromBottom': {
+                return {
+                    initial: {y: '100%'},
+                    animate: {y: '0%'},
+                    exit: {y: '100%'},
+                }
+            }
+
+            default: {
+                return {}
+            }
+        }
+    }
+
+    /**
+     * 배경 애니메이션 속성을 반환하는 함수
+     */
+    const getBackdropAnimationProperties = (): AnimationProperties => {
+        if (backdropAnimation === 'fade') {
+            return {
+                initial: {opacity: 0},
+                animate: {opacity: 1},
+                exit: {opacity: 0},
+                transition: {type: 'spring', damping: 25, stiffness: 300},
+            }
+        }
+        return {}
+    }
+
+    // 키보드 및 마우스 이벤트 핸들러 등록
+    useEffect(() => {
+        const eventHandlers: [string, EventListener][] = []
+
+        if (closeOnEscape) {
+            const handleEscape = (event: KeyboardEvent) => {
+                if (event.key === 'Escape') {
+                    clearModal()
+                }
+            }
+            eventHandlers.push(['keydown', handleEscape as EventListener])
+        }
+
+        if (closeOnClickOutside) {
+            const handleClickOutside = (event: MouseEvent) => {
+                if (modalReference.current && !modalReference.current.contains(event.target as Node)) {
+                    clearModal()
+                }
+            }
+            eventHandlers.push(['mousedown', handleClickOutside as EventListener])
+        }
+
+        // 이벤트 리스너 등록
+        for (const [event, handler] of eventHandlers) {
+            document.addEventListener(event, handler)
+        }
+
+        // 클린업
+        return () => {
+            for (const [event, handler] of eventHandlers) {
+                document.removeEventListener(event, handler)
+            }
+        }
+    }, [closeOnEscape, closeOnClickOutside, clearModal])
+
+    // body 스크롤 제어
+    useEffect(() => {
+        const originalOverflow = document.body.style.overflow
+
+        document.body.style.overflow = currentModal ? 'hidden' : originalOverflow
+
+        return () => {
+            document.body.style.overflow = originalOverflow
+        }
+    }, [currentModal])
+
+    /**
+     * 모달을 여는 함수
+     * @param properties - 모달 컴포넌트에 전달할 props
+     */
+    const openModal = (properties?: T): void => {
+        const modalContent = typeof modal === 'function' ? modal(properties as T) : modal
+
+        const backdropProperties = getBackdropAnimationProperties()
+        const modalProperties = getModalAnimationProperties()
+
+        if (backdrop) {
+            setModal(
+                <motion.div
+                    {...backdropProperties}
+                    className="fixed inset-0 bg-black/50 z-50"
+                    transition={{ease: 'easeOut', duration: 0.3}}
+                >
+                    <motion.div
+                        {...modalProperties}
+                        className="fixed inset-0 z-50"
+                        transition={{ease: 'easeOut', duration: 0.3}}
+                    >
+                        <div ref={modalReference}>{modalContent}</div>
+                    </motion.div>
+                </motion.div>,
+            )
+        } else {
+            setModal(
+                <motion.div
+                    {...modalProperties}
+                    className="fixed inset-0 z-50"
+                    transition={{ease: 'easeOut', duration: 0.3}}
+                >
+                    <div ref={modalReference}>{modalContent}</div>
+                </motion.div>,
+            )
+        }
+    }
+
+    /**
+     * 모달을 닫는 함수
+     */
+    const closeModal = (): void => {
+        clearModal()
+    }
+
+    return {openModal, closeModal}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Close: #12 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

다음 사항들을 주안점으로 두고 공용 모달 커스텀 훅을 구현했습니다.
- 모달을 컴포넌트화 하여 여러 페이지에서 재사용
- 모달의 공통 로직 분리
    - 애니메이션
    - 모달 바깥 영역을 클릭하거나 Esc 키를 누르면 모달 닫기
    - 모달 뒤 검은 배경
- 관심사의 분리
    - 페이지는 모달을 열고 닫는 로직에 집중
    - 커스텀 훅은 모달 공통 로직에 집중


### 코드 예시

```tsx
function App() {
  const { openModal } = useModal(<MyModal />, {
    closeOnEscape: false,        // ESC 키로 닫기 비활성화
    closeOnClickOutside: false,  // 외부 클릭으로 닫기 비활성화
    backdrop: false              // 배경 어둠 처리 비활성화
    modalAnimation: 'slideFromRight',   // 모달 애니메이션 설정
    backdropAnimation: 'fade'    // 배경 애니메이션 설정
  })
  
  return (
    <button onClick={openModal}>
      모달 열기
    </button>
  )
}
```

### useModal 문서화
https://mewing-halloumi-584.notion.site/useModal-22961be3ce8580c780c9e3d0160ce5a0?source=copy_link